### PR TITLE
test to ensure no change of the global config after unmarshling.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -370,6 +370,13 @@ func (c *ScrapeConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 		}
 	}
+
+	// Add index to the static config target groups for unique identification
+	// within scrape pool.
+	for i, tg := range c.ServiceDiscoveryConfig.StaticConfigs {
+		tg.Source = fmt.Sprintf("%d", i)
+	}
+
 	return nil
 }
 
@@ -432,6 +439,13 @@ func (c *AlertmanagerConfig) UnmarshalYAML(unmarshal func(interface{}) error) er
 			}
 		}
 	}
+
+	// Add index to the static config target groups for unique identification
+	// within scrape pool.
+	for i, tg := range c.ServiceDiscoveryConfig.StaticConfigs {
+		tg.Source = fmt.Sprintf("%d", i)
+	}
+
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -128,6 +128,7 @@ var expectedConf = &Config{
 							"my":   "label",
 							"your": "label",
 						},
+						Source: "0",
 					},
 				},
 
@@ -484,6 +485,7 @@ var expectedConf = &Config{
 						Targets: []model.LabelSet{
 							{model.AddressLabel: "localhost:9090"},
 						},
+						Source: "0",
 					},
 				},
 			},
@@ -503,6 +505,7 @@ var expectedConf = &Config{
 						Targets: []model.LabelSet{
 							{model.AddressLabel: "localhost:9090"},
 						},
+						Source: "0",
 					},
 				},
 			},
@@ -548,6 +551,7 @@ var expectedConf = &Config{
 								{model.AddressLabel: "1.2.3.5:9093"},
 								{model.AddressLabel: "1.2.3.6:9093"},
 							},
+							Source: "0",
 						},
 					},
 				},

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -279,7 +279,7 @@ func (d *Discovery) deleteTimestamp(filename string) {
 
 // stop shuts down the file watcher.
 func (d *Discovery) stop() {
-	level.Debug(d.logger).Log("msg", "Stopping file discovery...", "paths", d.paths)
+	level.Debug(d.logger).Log("msg", "Stopping file discovery...", "paths", fmt.Sprintf("%v", d.paths))
 
 	done := make(chan struct{})
 	defer close(done)
@@ -299,10 +299,10 @@ func (d *Discovery) stop() {
 		}
 	}()
 	if err := d.watcher.Close(); err != nil {
-		level.Error(d.logger).Log("msg", "Error closing file watcher", "paths", d.paths, "err", err)
+		level.Error(d.logger).Log("msg", "Error closing file watcher", "paths", fmt.Sprintf("%v", d.paths), "err", err)
 	}
 
-	level.Debug(d.logger).Log("File discovery stopped", "paths", d.paths)
+	level.Debug(d.logger).Log("msg", "File discovery stopped")
 }
 
 // refresh reads all files matching the discovery's patterns and sends the respective

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -285,7 +285,7 @@ func (m *Manager) providersFromConfig(cfg sd_config.ServiceDiscoveryConfig) map[
 		app("triton", i, t)
 	}
 	if len(cfg.StaticConfigs) > 0 {
-		app("static", 0, NewStaticProvider(cfg.StaticConfigs))
+		app("static", 0, &StaticProvider{cfg.StaticConfigs})
 	}
 
 	return providers
@@ -294,15 +294,6 @@ func (m *Manager) providersFromConfig(cfg sd_config.ServiceDiscoveryConfig) map[
 // StaticProvider holds a list of target groups that never change.
 type StaticProvider struct {
 	TargetGroups []*targetgroup.Group
-}
-
-// NewStaticProvider returns a StaticProvider configured with the given
-// target groups.
-func NewStaticProvider(groups []*targetgroup.Group) *StaticProvider {
-	for i, tg := range groups {
-		tg.Source = fmt.Sprintf("%d", i)
-	}
-	return &StaticProvider{groups}
 }
 
 // Run implements the Worker interface.

--- a/web/web.go
+++ b/web/web.go
@@ -71,17 +71,6 @@ import (
 
 var localhostRepresentations = []string{"127.0.0.1", "localhost"}
 
-// secureHeadersMiddleware adds common HTTP security headers to responses.
-func secureHeadersMiddleware(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("X-XSS-Protection", "1; mode=block")
-		w.Header().Add("X-Content-Type-Options", "nosniff")
-		w.Header().Add("X-Frame-Options", "SAMEORIGIN")
-		w.Header().Add("Content-Security-Policy", "frame-ancestors 'self'")
-		h.ServeHTTP(w, r)
-	})
-}
-
 var (
 	requestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -489,10 +478,8 @@ func (h *Handler) Run(ctx context.Context) error {
 
 	errlog := stdlog.New(log.NewStdlibAdapter(level.Error(h.logger)), "", 0)
 
-	withSecureHeaders := nethttp.Middleware(opentracing.GlobalTracer(), secureHeadersMiddleware(mux), operationName)
-
 	httpSrv := &http.Server{
-		Handler:     withSecureHeaders,
+		Handler:     nethttp.Middleware(opentracing.GlobalTracer(), mux, operationName),
 		ErrorLog:    errlog,
 		ReadTimeout: h.options.ReadTimeout,
 	}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -83,54 +83,6 @@ func TestGlobalURL(t *testing.T) {
 	}
 }
 
-func TestEndpointHeaders(t *testing.T) {
-	t.Parallel()
-	dbDir, err := ioutil.TempDir("", "tsdb-ready")
-
-	testutil.Ok(t, err)
-
-	defer os.RemoveAll(dbDir)
-
-	db, err := libtsdb.Open(dbDir, nil, nil, nil)
-
-	testutil.Ok(t, err)
-
-	opts := &Options{
-		ListenAddress:  ":9095",
-		ReadTimeout:    30 * time.Second,
-		MaxConnections: 512,
-		Context:        nil,
-		Storage:        &tsdb.ReadyStorage{},
-		QueryEngine:    nil,
-		RuleManager:    nil,
-		Notifier:       nil,
-		RoutePrefix:    "/",
-		EnableAdminAPI: true,
-		TSDB:           func() *libtsdb.DB { return db },
-	}
-
-	opts.Flags = map[string]string{}
-
-	webHandler := New(nil, opts)
-	go func() {
-		err := webHandler.Run(context.Background())
-		if err != nil {
-			panic(fmt.Sprintf("Can't start webhandler error %s", err))
-		}
-	}()
-
-	time.Sleep(5 * time.Second)
-
-	resp, err := http.Get("http://localhost:9095/version")
-
-	testutil.Ok(t, err)
-	testutil.Equals(t, "1; mode=block", resp.Header.Get("X-XSS-Protection"))
-	testutil.Equals(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
-	testutil.Equals(t, "SAMEORIGIN", resp.Header.Get("X-Frame-Options"))
-	testutil.Equals(t, "frame-ancestors 'self'", resp.Header.Get("Content-Security-Policy"))
-
-}
-
 func TestReadyAndHealthy(t *testing.T) {
 	t.Parallel()
 	dbDir, err := ioutil.TempDir("", "tsdb-ready")


### PR DESCRIPTION
Came up with this idea for a more global check.

In general the config handling needs some serious refactoring as this global state and pointers have caused few other issues and races and  I think this will bite us again.

Last time I suggested some changes Brian was against it so for now leaving as is.

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>